### PR TITLE
Add support for usize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,9 @@ impl Zero for u64 {
 impl Zero for u128 {
     const ZERO: Self = 0;
 }
+impl Zero for usize {
+    const ZERO: Self = 0;
+}
 
 fn gcd<T>(a: T, b: T) -> T
 where


### PR DESCRIPTION
Hi! 

First of all, thanks so much for this project, as well as your lcmx repo! I stumbled on lcmx on crates.io while solving an [advent of code problem](https://adventofcode.com/2023/day/8). 

While using the crate, I initially tried working with a vector of ``usize``'s, but realized its contents didn't satisfy the ``gcdx::Zero`` trait bound. I added an implementation for ``usize`` in this PR, but if you don't want the project to support/ there's a reason for not supporting ``usize``'s I completely understand :)

Again, thanks so much for this! 